### PR TITLE
Add basic ping test script

### DIFF
--- a/ping.js
+++ b/ping.js
@@ -1,0 +1,16 @@
+// Afghan Voice - Gateway Ping Tester
+const exec = require('child_process').exec;
+
+const gatewayIP = '165.22.109.195';
+
+exec(`ping -c 4 ${gatewayIP}`, (error, stdout, stderr) => {
+    if (error) {
+        console.error(`❌ Error pinging gateway: ${error.message}`);
+        return;
+    }
+    if (stderr) {
+        console.error(`⚠️ stderr: ${stderr}`);
+        return;
+    }
+    console.log(`✅ Gateway response:\n${stdout}`);
+});


### PR DESCRIPTION
This script is used to ping the Afghan Voice gateway server (165.22.109.195) to check its network connectivity and response time. It helps diagnose if the gateway is online or facing network issues.